### PR TITLE
Fix strict null checks and typo

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -44,7 +44,7 @@ To build sample extension, run `npm run build`, which will create the following 
 * `/dist/manifest.json` – Chrome Extension Manifest V3 file.
 
 ## Npm package
-To create an nmp package, run `npm pack` command, which will create **cameyo-virtual-channel-sdk-version.tgz**.
+To create an npm package, run `npm pack` command, which will create **cameyo-virtual-channel-sdk-version.tgz**.
 
 To install this package into your project, use `npm install cameyo-virtual-channel-sdk-version.tgz` command.
 

--- a/client/src/virtual_channel_handler.ts
+++ b/client/src/virtual_channel_handler.ts
@@ -86,7 +86,11 @@ export namespace Cameyo.VirtualChannels {
     }
 
     protected onPortConnected(port: chrome.runtime.Port) {
-      if (!port.sender.origin.includes('cameyo.com') && !port.sender.origin.includes('cameyo.net')) {
+      if (
+        port.sender === undefined ||
+        port.sender.origin === undefined ||
+        (!port.sender.origin.includes('cameyo.com') && !port.sender.origin.includes('cameyo.net'))
+      ) {
         return;
       }
 


### PR DESCRIPTION
Checking `port.sender` and `port.sender.origin` for undefined before accessing is required for compilation with strict null checks (required to import into google3).