### PR TITLE
Fix EXPORT_NOT_A_STATEMENT issue

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cameyo-virtual-channel-sdk",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "description": "Cameyo Virtual Channel SDK",
   "main": "dist/sdk.js",
   "types": "dist/index.d.ts",

--- a/client/src/virtual_channel_handler.ts
+++ b/client/src/virtual_channel_handler.ts
@@ -23,7 +23,7 @@
  * SOFTWARE.
  */
 
-export namespace Cameyo.VirtualChannels {
+namespace Cameyo.VirtualChannels {
   const divider = '_###_';
   const connectionHandleRegex = new RegExp(`^(.*)${divider}([a-zA-Z0-9]{8}-(?:[a-zA-Z0-9]{4}-){3}[a-zA-Z0-9]{12})$`);
 
@@ -159,3 +159,5 @@ export namespace Cameyo.VirtualChannels {
     }
   }
 }
+
+export {Cameyo};


### PR DESCRIPTION
This is mostly to adhere to Google-internal style guides and should be the last change needed. I could also make this change with a local patch in our internal copy, but it would be easier to maintain if it would be in the upstream repo.